### PR TITLE
all: optimize LineTo, CurveTo and methods formatting numbers

### DIFF
--- a/def.go
+++ b/def.go
@@ -601,6 +601,10 @@ type Fpdf struct {
 	}
 	spotColorMap           map[string]spotColorType // Map of named ink-based colors
 	userUnderlineThickness float64                  // A custom user underline thickness multiplier.
+
+	fmt struct {
+		buf []byte // buffer used to format numbers.
+	}
 }
 
 type encType struct {

--- a/fpdf_test.go
+++ b/fpdf_test.go
@@ -2929,3 +2929,21 @@ func ExampleFpdf_SetModificationDate() {
 	// Output:
 	// Successfully generated pdf/Fpdf_SetModificationDate.pdf
 }
+
+func BenchmarkLineTo(b *testing.B) {
+	pdf := fpdf.New("P", "mm", "A4", "")
+	pdf.AddPage()
+
+	for i := 0; i < b.N; i++ {
+		pdf.LineTo(170, 20)
+	}
+}
+
+func BenchmarkCurveTo(b *testing.B) {
+	pdf := fpdf.New("P", "mm", "A4", "")
+	pdf.AddPage()
+
+	for i := 0; i < b.N; i++ {
+		pdf.CurveTo(190, 100, 105, 100)
+	}
+}


### PR DESCRIPTION
This CL adds a per-doc formatting buffer that is used when formatting
numbers.

  ```
  name       old time/op    new time/op    delta
  LineTo-8      500ns ± 1%     343ns ± 1%   -31.47%  (p=0.000 n=19+18)
  CurveTo-8    1.00µs ± 2%    0.74µs ± 0%   -25.86%  (p=0.000 n=20+18)

  name       old alloc/op   new alloc/op   delta
  LineTo-8      77.0B ± 0%     47.5B ± 1%   -38.38%  (p=0.000 n=17+20)
  CurveTo-8      228B ± 7%      118B ± 1%   -48.33%  (p=0.000 n=20+20)

  name       old allocs/op  new allocs/op  delta
  LineTo-8       3.00 ± 0%      0.00       -100.00%  (p=0.000 n=20+20)
  CurveTo-8      5.00 ± 0%      0.00       -100.00%  (p=0.000 n=20+20)
  ```