### PR TITLE
fpdf: introduce buffer pool for (de)flating buffers

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -39,7 +39,9 @@ func checksum(data []byte) string {
 func (f *Fpdf) writeCompressedFileObject(content []byte) {
 	lenUncompressed := len(content)
 	sum := checksum(content)
-	compressed := sliceCompress(content)
+	mem := xmem.compress(content)
+	defer mem.release()
+	compressed := mem.bytes()
 	lenCompressed := len(compressed)
 	f.newobj()
 	f.outf("<< /Type /EmbeddedFile /Length %d /Filter /FlateDecode /Params << /CheckSum <%s> /Size %d >> >>\n",

--- a/fpdf.go
+++ b/fpdf.go
@@ -23,7 +23,6 @@ package fpdf
 
 import (
 	"bytes"
-	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"image"
@@ -3913,7 +3912,7 @@ func (f *Fpdf) parsejpg(r io.Reader) (info *ImageInfoType) {
 
 // parsepng extracts info from a PNG data
 func (f *Fpdf) parsepng(r io.Reader, readdpi bool) (info *ImageInfoType) {
-	buf, err := bufferFromReader(r)
+	buf, err := newRBuffer(r)
 	if err != nil {
 		f.err = err
 		return
@@ -3921,25 +3920,9 @@ func (f *Fpdf) parsepng(r io.Reader, readdpi bool) (info *ImageInfoType) {
 	return f.parsepngstream(buf, readdpi)
 }
 
-func (f *Fpdf) readBeInt32(r io.Reader) (val int32) {
-	err := binary.Read(r, binary.BigEndian, &val)
-	if err != nil && err != io.EOF {
-		f.err = err
-	}
-	return
-}
-
-func (f *Fpdf) readByte(r io.Reader) (val byte) {
-	err := binary.Read(r, binary.BigEndian, &val)
-	if err != nil {
-		f.err = err
-	}
-	return
-}
-
 // parsegif extracts info from a GIF data (via PNG conversion)
 func (f *Fpdf) parsegif(r io.Reader) (info *ImageInfoType) {
-	data, err := bufferFromReader(r)
+	data, err := newRBuffer(r)
 	if err != nil {
 		f.err = err
 		return
@@ -3956,7 +3939,7 @@ func (f *Fpdf) parsegif(r io.Reader) (info *ImageInfoType) {
 		f.err = err
 		return
 	}
-	return f.parsepngstream(pngBuf, false)
+	return f.parsepngstream(&rbuffer{p: pngBuf.Bytes()}, false)
 }
 
 // newobj begins a new object
@@ -4194,9 +4177,11 @@ func (f *Fpdf) putpages() {
 		// Page content
 		f.newobj()
 		if f.compress {
-			data := sliceCompress(f.pages[n].Bytes())
+			mem := xmem.compress(f.pages[n].Bytes())
+			data := mem.bytes()
 			f.outf("<</Filter /FlateDecode /Length %d>>", len(data))
 			f.putstream(data)
+			mem.release()
 		} else {
 			f.outf("<</Length %d>>", f.pages[n].Len())
 			f.putstream(f.pages[n].Bytes())
@@ -4363,7 +4348,6 @@ func (f *Fpdf) putfonts() {
 				delete(usedRunes, 0)
 				utf8FontStream := font.utf8File.GenerateCutFont(usedRunes)
 				utf8FontSize := len(utf8FontStream)
-				compressedFontStream := sliceCompress(utf8FontStream)
 				CodeSignDictionary := font.utf8File.CodeSymbolDictionary
 				delete(CodeSignDictionary, 0)
 
@@ -4418,13 +4402,17 @@ func (f *Fpdf) putfonts() {
 					cidToGidMap[cc*2+1] = byte(glyph & 0xFF)
 				}
 
-				cidToGidMap = sliceCompress(cidToGidMap)
+				mem := xmem.compress(cidToGidMap)
+				cidToGidMap = mem.bytes()
 				f.newobj()
 				f.out("<</Length " + strconv.Itoa(len(cidToGidMap)) + "/Filter /FlateDecode>>")
 				f.putstream(cidToGidMap)
 				f.out("endobj")
+				mem.release()
 
 				//Font file
+				mem = xmem.compress(utf8FontStream)
+				compressedFontStream := mem.bytes()
 				f.newobj()
 				f.out("<</Length " + strconv.Itoa(len(compressedFontStream)))
 				f.out("/Filter /FlateDecode")
@@ -4432,6 +4420,7 @@ func (f *Fpdf) putfonts() {
 				f.out(">>")
 				f.putstream(compressedFontStream)
 				f.out("endobj")
+				mem.release()
 			default:
 				f.err = fmt.Errorf("unsupported font type: %s", tp)
 				return
@@ -4679,9 +4668,11 @@ func (f *Fpdf) putimage(info *ImageInfoType) {
 	if info.cs == "Indexed" {
 		f.newobj()
 		if f.compress {
-			pal := sliceCompress(info.pal)
+			mem := xmem.compress(info.pal)
+			pal := mem.bytes()
 			f.outf("<</Filter /FlateDecode /Length %d>>", len(pal))
 			f.putstream(pal)
+			mem.release()
 		} else {
 			f.outf("<</Length %d>>", len(info.pal))
 			f.putstream(info.pal)

--- a/fpdf_test.go
+++ b/fpdf_test.go
@@ -2934,6 +2934,7 @@ func BenchmarkLineTo(b *testing.B) {
 	pdf := fpdf.New("P", "mm", "A4", "")
 	pdf.AddPage()
 
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		pdf.LineTo(170, 20)
 	}
@@ -2943,6 +2944,7 @@ func BenchmarkCurveTo(b *testing.B) {
 	pdf := fpdf.New("P", "mm", "A4", "")
 	pdf.AddPage()
 
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		pdf.CurveTo(190, 100, 105, 100)
 	}

--- a/png_test.go
+++ b/png_test.go
@@ -1,0 +1,89 @@
+// Copyright ©2021 The go-pdf Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package fpdf
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+)
+
+func BenchmarkParsePNG_rgb(b *testing.B) {
+	raw, err := ioutil.ReadFile("image/golang-gopher.png")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	pdf := New("P", "mm", "A4", "")
+	pdf.AddPage()
+
+	const readDPI = true
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = pdf.parsepng(bytes.NewReader(raw), readDPI)
+	}
+}
+
+func BenchmarkParsePNG_gray(b *testing.B) {
+	raw, err := ioutil.ReadFile("image/logo-gray.png")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	pdf := New("P", "mm", "A4", "")
+	pdf.AddPage()
+
+	const readDPI = true
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = pdf.parsepng(bytes.NewReader(raw), readDPI)
+	}
+}
+
+func BenchmarkParsePNG_small(b *testing.B) {
+	raw, err := ioutil.ReadFile("image/logo.png")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	pdf := New("P", "mm", "A4", "")
+	pdf.AddPage()
+
+	const readDPI = true
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = pdf.parsepng(bytes.NewReader(raw), readDPI)
+	}
+}
+
+func BenchmarkParseJPG(b *testing.B) {
+	raw, err := ioutil.ReadFile("image/logo_gofpdf.jpg")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	pdf := New("P", "mm", "A4", "")
+	pdf.AddPage()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = pdf.parsejpg(bytes.NewReader(raw))
+	}
+}
+
+func BenchmarkParseGIF(b *testing.B) {
+	raw, err := ioutil.ReadFile("image/logo.gif")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	pdf := New("P", "mm", "A4", "")
+	pdf.AddPage()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = pdf.parsegif(bytes.NewReader(raw))
+	}
+}

--- a/rbuf.go
+++ b/rbuf.go
@@ -1,0 +1,72 @@
+// Copyright ©2021 The go-pdf Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package fpdf
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+)
+
+type rbuffer struct {
+	p []byte
+	c int
+}
+
+// newRBuffer returns a new buffer populated with the contents of the specified Reader
+func newRBuffer(r io.Reader) (b *rbuffer, err error) {
+	buf := new(bytes.Buffer)
+	_, err = buf.ReadFrom(r)
+	b = &rbuffer{p: buf.Bytes()}
+	return
+}
+
+func (r *rbuffer) Read(p []byte) (int, error) {
+	if r.c >= len(r.p) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.p[r.c:])
+	r.c += n
+	return n, nil
+}
+
+func (r *rbuffer) ReadByte() (byte, error) {
+	if r.c >= len(r.p) {
+		return 0, io.EOF
+	}
+	v := r.p[r.c]
+	r.c++
+	return v, nil
+}
+
+func (r *rbuffer) u8() uint8 {
+	if r.c >= len(r.p) {
+		panic(io.ErrShortBuffer)
+	}
+	v := r.p[r.c]
+	r.c++
+	return v
+}
+
+func (r *rbuffer) u32() uint32 {
+	const n = 4
+	if r.c+n >= len(r.p) {
+		panic(io.ErrShortBuffer)
+	}
+	beg := r.c
+	r.c += n
+	v := binary.BigEndian.Uint32(r.p[beg:])
+	return v
+}
+
+func (r *rbuffer) i32() int32 {
+	return int32(r.u32())
+}
+
+func (r *rbuffer) Next(n int) []byte {
+	c := r.c
+	r.c += n
+	return r.p[c:r.c]
+}

--- a/template.go
+++ b/template.go
@@ -205,13 +205,18 @@ func (f *Fpdf) putTemplates() {
 
 		//  Write the template's byte stream
 		buffer := t.Bytes()
+		var mem *membuffer
 		// fmt.Println("Put template bytes", string(buffer[:]))
 		if f.compress {
-			buffer = sliceCompress(buffer)
+			mem = xmem.compress(buffer)
+			buffer = mem.bytes()
 		}
 		f.outf("/Length %d >>", len(buffer))
 		f.putstream(buffer)
 		f.out("endobj")
+		if mem != nil {
+			mem.release()
+		}
 	}
 }
 

--- a/util.go
+++ b/util.go
@@ -19,7 +19,6 @@ package fpdf
 import (
 	"bufio"
 	"bytes"
-	"compress/zlib"
 	"fmt"
 	"io"
 	"math"
@@ -69,55 +68,6 @@ func fileSize(filename string) (size int64, ok bool) {
 	ok = err == nil
 	if ok {
 		size = info.Size()
-	}
-	return
-}
-
-// bufferFromReader returns a new buffer populated with the contents of the specified Reader
-func bufferFromReader(r io.Reader) (b *bytes.Buffer, err error) {
-	b = new(bytes.Buffer)
-	_, err = b.ReadFrom(r)
-	return
-}
-
-// sliceCompress returns a zlib-compressed copy of the specified byte array
-func sliceCompress(data []byte) []byte {
-	var buf bytes.Buffer
-	buf.Grow(len(data))
-	cmp, err := zlib.NewWriterLevel(&buf, zlib.BestSpeed)
-	if err != nil {
-		panic(fmt.Errorf("could not create zlib writer: %w", err))
-	}
-	_, err = cmp.Write(data)
-	if err != nil {
-		panic(fmt.Errorf("could not zlib-compress slice: %w", err))
-	}
-
-	err = cmp.Close()
-	if err != nil {
-		panic(fmt.Errorf("could not close zlib writer: %w", err))
-	}
-
-	raw := buf.Bytes()
-	return raw[:len(raw):len(raw)]
-}
-
-// sliceUncompress returns an uncompressed copy of the specified zlib-compressed byte array
-func sliceUncompress(data []byte) (outData []byte, err error) {
-	inBuf := bytes.NewReader(data)
-	r, err := zlib.NewReader(inBuf)
-	defer func() {
-		e1 := r.Close()
-		if e1 != nil && err == nil {
-			err = e1
-		}
-	}()
-	if err == nil {
-		var outBuf bytes.Buffer
-		_, err = outBuf.ReadFrom(r)
-		if err == nil {
-			outData = outBuf.Bytes()
-		}
 	}
 	return
 }

--- a/wbuf.go
+++ b/wbuf.go
@@ -1,0 +1,17 @@
+// Copyright ©2021 The go-pdf Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package fpdf
+
+type wbuffer struct {
+	p []byte
+	c int
+}
+
+func (w *wbuffer) u8(v uint8) {
+	w.p[w.c] = v
+	w.c++
+}
+
+func (w *wbuffer) bytes() []byte { return w.p }

--- a/xcompr.go
+++ b/xcompr.go
@@ -1,0 +1,79 @@
+// Copyright ©2021 The go-pdf Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package fpdf
+
+import (
+	"bytes"
+	"compress/zlib"
+	"fmt"
+	"sync"
+)
+
+var xmem = xmempool{
+	Pool: sync.Pool{
+		New: func() interface{} {
+			var m membuffer
+			return &m
+		},
+	},
+}
+
+type xmempool struct{ sync.Pool }
+
+func (pool *xmempool) compress(data []byte) *membuffer {
+	mem := pool.Get().(*membuffer)
+	buf := &mem.buf
+	buf.Grow(len(data))
+
+	zw, err := zlib.NewWriterLevel(buf, zlib.BestSpeed)
+	if err != nil {
+		panic(fmt.Errorf("could not create zlib writer: %w", err))
+	}
+	_, err = zw.Write(data)
+	if err != nil {
+		panic(fmt.Errorf("could not zlib-compress slice: %w", err))
+	}
+
+	err = zw.Close()
+	if err != nil {
+		panic(fmt.Errorf("could not close zlib writer: %w", err))
+	}
+	return mem
+}
+
+func (pool *xmempool) uncompress(data []byte) (*membuffer, error) {
+	zr, err := zlib.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+
+	mem := pool.Get().(*membuffer)
+	mem.buf.Reset()
+
+	_, err = mem.buf.ReadFrom(zr)
+	if err != nil {
+		mem.release()
+		return nil, err
+	}
+
+	return mem, nil
+}
+
+type membuffer struct {
+	buf bytes.Buffer
+}
+
+func (mem *membuffer) bytes() []byte { return mem.buf.Bytes() }
+func (mem *membuffer) release() {
+	mem.buf.Reset()
+	xmem.Put(mem)
+}
+
+func (mem *membuffer) copy() []byte {
+	src := mem.bytes()
+	dst := make([]byte, len(src))
+	copy(dst, src)
+	return dst
+}


### PR DESCRIPTION
```
name              old time/op    new time/op    delta
ParsePNG_rgb-8      22.8ms ± 1%    16.0ms ± 3%  -29.81%  (p=0.000 n=25+30)
ParsePNG_gray-8      660µs ± 3%     624µs ± 4%   -5.54%  (p=0.000 n=28+30)
ParsePNG_small-8    2.49µs ± 2%    2.12µs ± 3%  -14.83%  (p=0.000 n=30+30)
ParseJPG-8          36.3µs ± 4%    36.8µs ± 5%     ~     (p=0.070 n=30+30)
ParseGIF-8           410µs ± 3%     409µs ± 4%     ~     (p=0.562 n=30+29)

name              old alloc/op   new alloc/op   delta
ParsePNG_rgb-8      26.4MB ± 0%     4.2MB ±10%  -84.04%  (p=0.000 n=29+30)
ParsePNG_gray-8     2.56MB ± 0%    2.49MB ± 0%   -2.73%  (p=0.000 n=30+30)
ParsePNG_small-8    8.96kB ± 0%    9.84kB ± 0%   +9.73%  (p=0.000 n=30+30)
ParseJPG-8           274kB ± 0%     274kB ± 0%   -0.00%  (p=0.002 n=30+30)
ParseGIF-8           897kB ± 0%     898kB ± 0%   +0.10%  (p=0.000 n=30+30)

name              old allocs/op  new allocs/op  delta
ParsePNG_rgb-8         400 ± 0%       292 ± 0%  -27.00%  (p=0.000 n=30+28)
ParsePNG_gray-8        164 ± 0%       114 ± 0%  -30.49%  (p=0.000 n=30+30)
ParsePNG_small-8      35.0 ± 0%      10.0 ± 0%  -71.43%  (p=0.000 n=30+30)
ParseJPG-8            12.0 ± 0%      12.0 ± 0%     ~     (all equal)
ParseGIF-8             214 ± 0%       191 ± 0%  -10.75%  (p=0.000 n=30+30)
```