### PR TITLE
fpdf: allow to set global document language

### DIFF
--- a/def.go
+++ b/def.go
@@ -634,7 +634,7 @@ type Fpdf struct {
 	title            string                     // title
 	subject          string                     // subject
 	author           string                     // author
-	documentLang     string                     // lang
+	lang             string                     // lang
 	keywords         string                     // keywords
 	creator          string                     // creator
 	creationDate     time.Time                  // override for document CreationDate value

--- a/def.go
+++ b/def.go
@@ -479,6 +479,7 @@ type Pdf interface {
 	SetCreator(creatorStr string, isUTF8 bool)
 	SetDashPattern(dashArray []float64, dashPhase float64)
 	SetDisplayMode(zoomStr, layoutStr string)
+	SetDocumentLang(lang string)
 	SetDrawColor(r, g, b int)
 	SetDrawSpotColor(nameStr string, tint byte)
 	SetError(err error)
@@ -633,6 +634,7 @@ type Fpdf struct {
 	title            string                     // title
 	subject          string                     // subject
 	author           string                     // author
+	documentLang     string                     // lang
 	keywords         string                     // keywords
 	creator          string                     // creator
 	creationDate     time.Time                  // override for document CreationDate value

--- a/def.go
+++ b/def.go
@@ -479,7 +479,7 @@ type Pdf interface {
 	SetCreator(creatorStr string, isUTF8 bool)
 	SetDashPattern(dashArray []float64, dashPhase float64)
 	SetDisplayMode(zoomStr, layoutStr string)
-	SetDocumentLang(lang string)
+	SetLang(lang string)
 	SetDrawColor(r, g, b int)
 	SetDrawSpotColor(nameStr string, tint byte)
 	SetError(err error)

--- a/fpdf.go
+++ b/fpdf.go
@@ -605,6 +605,11 @@ func (f *Fpdf) SetAuthor(authorStr string, isUTF8 bool) {
 	f.author = authorStr
 }
 
+// SetDocumentLang defines natural language of the document (e.g. "de-CH").
+func (f *Fpdf) SetDocumentLang(lang string) {
+	f.documentLang = lang
+}
+
 // SetKeywords defines the keywords of the document. keywordStr is a
 // space-delimited string, for example "invoice August". isUTF8 indicates if
 // the string is encoded
@@ -4892,6 +4897,9 @@ func (f *Fpdf) putinfo() {
 func (f *Fpdf) putcatalog() {
 	f.out("/Type /Catalog")
 	f.out("/Pages 1 0 R")
+	if f.documentLang != "" {
+		f.outf("/Lang (%s)", f.documentLang)
+	}
 	switch f.zoomMode {
 	case "fullpage":
 		f.out("/OpenAction [3 0 R /Fit]")

--- a/fpdf.go
+++ b/fpdf.go
@@ -605,9 +605,9 @@ func (f *Fpdf) SetAuthor(authorStr string, isUTF8 bool) {
 	f.author = authorStr
 }
 
-// SetDocumentLang defines natural language of the document (e.g. "de-CH").
-func (f *Fpdf) SetDocumentLang(lang string) {
-	f.documentLang = lang
+// SetLang defines the natural language of the document (e.g. "de-CH").
+func (f *Fpdf) SetLang(lang string) {
+	f.lang = lang
 }
 
 // SetKeywords defines the keywords of the document. keywordStr is a

--- a/fpdf.go
+++ b/fpdf.go
@@ -4897,8 +4897,8 @@ func (f *Fpdf) putinfo() {
 func (f *Fpdf) putcatalog() {
 	f.out("/Type /Catalog")
 	f.out("/Pages 1 0 R")
-	if f.documentLang != "" {
-		f.outf("/Lang (%s)", f.documentLang)
+	if f.lang != "" {
+		f.outf("/Lang (%s)", f.lang)
 	}
 	switch f.zoomMode {
 	case "fullpage":


### PR DESCRIPTION
The Document Catalog of a PDF allows to "specify the natural language for all text in the document" [1]. This is important to make PDFs accessible.

This change allows to set the Lang entry in the document catalog.

[1] PDF 1.7, section 7.7.2, page 74
https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf