### PR TITLE
Problem in SplitText

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-pdf/fpdf
+module github.com/francescoalemanno/fpdf
 
 go 1.20
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/francescoalemanno/fpdf
+module github.com/francescoalemanno/myfpdf
 
 go 1.20
 

--- a/splittext.go
+++ b/splittext.go
@@ -28,8 +28,8 @@ func (f *Fpdf) SplitText(txt string, w float64) (lines []string) {
 	l := 0
 	for i < nb {
 		c := s[i]
-		l += cw[c]
-		if unicode.IsSpace(c) || isChinese(c) {
+		l += cw[c%256]
+		if unicode.IsSpace(c) {
 			sep = i
 		}
 		if c == '\n' || l > wmax {


### PR DESCRIPTION
Dear Authors of FPDF

I had to fork this library since there is an unsafe use of array indexing within the SplitText function
in particural indexing the array 'cw' directly with rune 'c' leads to a chrash if for example i put the symbol € in the string.

The code within this PR is merely to point out the issue, I leave to you a more proper solution

Francesco