### PR TITLE
Fix error in SplitText when rune not in font range

### DIFF
--- a/fpdf_test.go
+++ b/fpdf_test.go
@@ -247,6 +247,27 @@ func TestFooterFuncLpi(t *testing.T) {
 	}
 }
 
+func TestIssue0069PanicOnSplitTextWithUnicode(t *testing.T) {
+	var str string
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("%q make SplitText panic", str)
+		}
+	}()
+
+	pdf := fpdf.New("P", "mm", "A4", "")
+	pdf.AddPage()
+	pdf.SetFont("Arial", "", 8)
+
+	testChars := []string{"«", "»", "—"}
+
+	for _, str = range testChars {
+		_ = pdf.SplitText(str, 100)
+	}
+
+}
+
 func TestSplitTextHandleCharacterNotInFontRange(t *testing.T) {
 	var str string
 

--- a/fpdf_test.go
+++ b/fpdf_test.go
@@ -247,6 +247,31 @@ func TestFooterFuncLpi(t *testing.T) {
 	}
 }
 
+func TestSplitTextHandleCharacterNotInFontRange(t *testing.T) {
+	var str string
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("%q text make SplitText panic", str)
+		}
+	}()
+
+	pdf := fpdf.New("P", "mm", "A4", "")
+	pdf.AddPage()
+	pdf.SetFont("Arial", "", 8)
+
+	// Test values in utf8 beyond the ascii range
+	// I assuming that if the function can handle values in this range
+	// it can handle others since the function basically use the rune codepoint
+	// as a index for the font char width and 1_000_000 elements must be
+	// enough (hopefully!) for the fonts used in the real world.
+	for i := 128; i < 1_000_000; i++ {
+		str = string(rune(i))
+		_ = pdf.SplitText(str, 100)
+	}
+
+}
+
 func BenchmarkLineTo(b *testing.B) {
 	pdf := fpdf.New("P", "mm", "A4", "")
 	pdf.AddPage()

--- a/splittext.go
+++ b/splittext.go
@@ -26,9 +26,20 @@ func (f *Fpdf) SplitText(txt string, w float64) (lines []string) {
 	i := 0
 	j := 0
 	l := 0
+	fontLength := len(cw)
+
 	for i < nb {
 		c := s[i]
-		l += cw[c]
+
+		if int(c) >= fontLength {
+			// decimal representation of c is greater than the font length so it can't be used as index.
+			// Here we substitute those values with a space but perhaps it will be better
+			// to set l as the max char width for that font.
+			l += cw[rune(' ')]
+		} else {
+			l += cw[c]
+		}
+
 		if unicode.IsSpace(c) || isChinese(c) {
 			sep = i
 		}

--- a/splittext.go
+++ b/splittext.go
@@ -26,16 +26,13 @@ func (f *Fpdf) SplitText(txt string, w float64) (lines []string) {
 	i := 0
 	j := 0
 	l := 0
-	fontLength := len(cw)
 
 	for i < nb {
 		c := s[i]
 
-		if int(c) >= fontLength {
-			// decimal representation of c is greater than the font length so it can't be used as index.
-			// Here we substitute those values with a space but perhaps it will be better
-			// to set l as the max char width for that font.
-			l += cw[rune(' ')]
+		if int(c) >= len(cw) {
+			// Decimal representation of c is greater than the font width's array size so it can't be used as index.
+			l += cw[f.currentFont.Desc.MissingWidth]
 		} else {
 			l += cw[c]
 		}


### PR DESCRIPTION
Fix error in SplitText when the decimal representation of a rune is greater than the number of font characters (Issue #69)