### PR TITLE
fixed rendering bug for th, zh, ja

### DIFF
--- a/fpdf.go
+++ b/fpdf.go
@@ -2939,7 +2939,7 @@ func (f *Fpdf) MultiCell(w, h float64, txtStr, borderStr, alignStr string, fill 
 			}
 			continue
 		}
-		if c == ' ' || isChinese(c) {
+		if c == ' ' {
 			sep = i
 			ls = l
 			ns++
@@ -3073,7 +3073,12 @@ func (f *Fpdf) write(h float64, txtStr string, link int, linkStr string) {
 		if c == ' ' {
 			sep = i
 		}
-		l += float64(cw[int(c)])
+
+		if cw[int(c)] == 0 { //Marker width 0 used for missing symbols
+			l += float64(f.currentFont.Desc.MissingWidth)
+		} else if cw[int(c)] != 65535 { //Marker width 65535 used for zero width symbols
+			l += float64(cw[int(c)])
+		}
 		if l > wmax {
 			// Automatic line break
 			if sep == -1 {

--- a/splittext.go
+++ b/splittext.go
@@ -33,11 +33,11 @@ func (f *Fpdf) SplitText(txt string, w float64) (lines []string) {
 		if int(c) >= len(cw) {
 			// Decimal representation of c is greater than the font width's array size so it can't be used as index.
 			l += cw[f.currentFont.Desc.MissingWidth]
-		} else {
+		} else if cw[c] != 65535 { //Marker width 65535 used for zero width symbols
 			l += cw[c]
 		}
 
-		if unicode.IsSpace(c) || isChinese(c) {
+		if unicode.IsSpace(c) {
 			sep = i
 		}
 		if c == '\n' || l > wmax {

--- a/util.go
+++ b/util.go
@@ -415,14 +415,6 @@ func remove(arr []int, key int) []int {
 	return append(arr[:n], arr[n+1:]...)
 }
 
-func isChinese(rune2 rune) bool {
-	// chinese unicode: 4e00-9fa5
-	if rune2 >= rune(0x4e00) && rune2 <= rune(0x9fa5) {
-		return true
-	}
-	return false
-}
-
 // Condition font family string to PDF name compliance. See section 5.3 (Names)
 // in https://resources.infosecinstitute.com/pdf-file-format-basic-structure/
 func fontFamilyEscape(familyStr string) (escStr string) {


### PR DESCRIPTION
Fixes issue #80 by not excluding Chinese origin characters when calling SplitText(). Also fixes a rendering bug with zero width characters (found in languages like Thai).