### PR TITLE
fpdf: fix autobreak when next page already exists

### DIFF
--- a/fpdf.go
+++ b/fpdf.go
@@ -2566,7 +2566,12 @@ func (f *Fpdf) CellFormat(w, h float64, txtStr, borderStr string, ln int,
 			f.ws = 0
 			f.out("0 Tw")
 		}
-		f.AddPageFormat(f.curOrientation, f.curPageSize)
+		if f.PageNo() == f.PageCount() {
+			f.AddPageFormat(f.curOrientation, f.curPageSize)
+		} else {
+			f.page += 1
+			f.y = f.tMargin
+		}
 		if f.err != nil {
 			return
 		}


### PR DESCRIPTION
This PR fixes #85.

This is done by only creating a new page if we are currently on the last page.
Otherwise, we just advance the current page by one (use the already existing one) and update the y position to start at the top margin.